### PR TITLE
Daemon does not use port parameter

### DIFF
--- a/src/peerd/opts.rs
+++ b/src/peerd/opts.rs
@@ -151,7 +151,7 @@ impl Opts {
         } else if let Some(bind_addr) = self.listen {
             let addr = InetSocketAddr::socket(
                 bind_addr.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)).into(),
-                self.port(),
+                self.port.unwrap_or(self.port()),
             );
             PeerSocket::Listen(NodeAddr::new(node_id, addr))
         } else {


### PR DESCRIPTION
**Description**

The `peerd` daemon uses only the default port instead of the port number parameter. 

**Steps to Reproduce**

1. Launch `lnpd` **without** _--threaded_ argument.
2. Run `lnp-cli listen` with _--port_ argument.

**Expected: ** The `lnpd` launch `peerd` with defined port argument.
**Current: ** the `microservice::supervisor` try spawn `peerd` with port 9999 and causes **rust panic**  (`Unable to bind to Lightning network peer socket: Os { code: 98, kind: AddrInUse, message: "Address already in use" }`) 

This PR fixies this.