### PR TITLE
adding a hint to lnpd init to panic

### DIFF
--- a/src/lnpd/daemons.rs
+++ b/src/lnpd/daemons.rs
@@ -36,7 +36,7 @@ pub fn read_node_key_file(key_file: &Path) -> LocalNode {
     let mut file = fs::File::open(key_file).unwrap_or_else(|_| {
         panic!(
             "Unable to open key file '{}';\nplease check that the file exists and the daemon has \
-             access rights to it",
+             access rights to it. If you have not created a key file before, run \"lnpd init\"",
             key_file.display()
         )
     });

--- a/src/lnpd/daemons.rs
+++ b/src/lnpd/daemons.rs
@@ -36,7 +36,7 @@ pub fn read_node_key_file(key_file: &Path) -> LocalNode {
     let mut file = fs::File::open(key_file).unwrap_or_else(|_| {
         panic!(
             "Unable to open key file '{}';\nplease check that the file exists and the daemon has \
-             access rights to it. If you have not created a key file before, run \"lnpd init\"",
+             access rights to it. If you have not created a key file before, run \"lnpd init\". for more info you can run \"lnpd --help\"",
             key_file.display()
         )
     });


### PR DESCRIPTION
If a user simply installs the application and runs lnpd without any options or flags, they reach this panic statement. This PR adds a hint to the `lnpd init` and `help` commands, for users who are not familiar with a CLI. This should also maybe be changed to be a regular programm exit, instead of a panic! since the rusts hints of running it with the BACKTRACE option are unnecessary in this case. 