### PR TITLE
Fix chain mismatch

### DIFF
--- a/src/lnpd/funding.rs
+++ b/src/lnpd/funding.rs
@@ -167,8 +167,9 @@ impl FundingWallet {
 
         let is_correct_network = match (wallet_network, target_network) {
             (Network::Bitcoin, Network::Bitcoin) => true,
-            (Network::Testnet, Network::Testnet | Network::Regtest | Network::Signet) => true,
-            _ => false,
+            (Network::Bitcoin, _) => false,
+            (_, Network::Bitcoin) => false,
+            _ => true,
         };
 
         if !is_correct_network {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -175,7 +175,7 @@ pub struct Opts {
     #[clap(
         long,
         global = true,
-        default_value("pandora.network"),
+        default_value("electrum.blockstream.info"),
         env = "LNP_NODE_ELECTRUM_SERVER",
         value_hint = ValueHint::Hostname
     )]


### PR DESCRIPTION
**Descriptor**

When we start the lnp-node with regtest, occurs the  ChainMismatch error, because `wallet_network is equal Regtest`. 

This PR fix the verification.   