### PR TITLE
Fix struct fields order

### DIFF
--- a/src/bus/ctl.rs
+++ b/src/bus/ctl.rs
@@ -196,9 +196,6 @@ pub struct AcceptChannelFrom {
     /// Client identifier to report about the progress
     pub report_to: Option<ServiceId>,
 
-    /// Request received from a remote peer to open channel
-    pub channel_req: OpenChannel,
-
     /// Channel policies
     pub policy: Policy,
 
@@ -210,6 +207,9 @@ pub struct AcceptChannelFrom {
 
     /// Channel local keyset
     pub local_keys: LocalKeyset,
+
+    /// Request received from a remote peer to open channel
+    pub channel_req: OpenChannel,
 }
 
 /// Request information about constructing funding transaction


### PR DESCRIPTION
I tried open a channel between two `lnp nodes`, but this error occurs:

```
[2023-01-10T08:59:31Z ERROR microservices::esb::controller] ESB request processing error: message serialization or structure error. Details: Data integrity problem during strict decoding operation: encoded values are not deterministically ordered: value `Type(10995120572727296)` should go before `Type(10995120572727302)`
```

After invetigate, I found the reason:

For some reason, the type `tvl::Stream (BTreeMap<Type, RawValue>)` need the last field of the struct when we uses strict encode/decode.
