### PR TITLE
v0.8.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lnp-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "amplify",
  "clap",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "lnp_node"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "amplify",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "rpc", "cli"]
 [package]
 name = "lnp_node"
 description = "LNP node"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 license = "MIT"
 keywords = ["bitcoin", "bifi", "lightning-network", "smart-contracts", "lnp"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lnp-cli"
 description = "LNP node command-line interface"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 license = "MIT"
 keywords = ["bitcoin", "node", "lightning-network", "smart-contracts", "lnp"]


### PR DESCRIPTION
As requested by @zoedberg

What has to be included before the merge:
~~- [ ] Release v0.8.1 of LNP Core with all backports and fixes from v0.9~~
~~- [ ] Review & merge pending commits in this repo + backport them~~
~~- [ ] Backport already released fixes from v0.9 https://github.com/LNP-WG/lnp-node/pull/72~~
~~- [ ] Cherry-pick the rest of commits from master which can't be merged directly since they happened after dependency version bump~~
~~- [ ] Fix CI issue~~